### PR TITLE
データベース修正

### DIFF
--- a/db/migrate/20200619083000_create_categories.rb
+++ b/db/migrate/20200619083000_create_categories.rb
@@ -2,10 +2,8 @@ class CreateCategories < ActiveRecord::Migration[5.2]
   def change
     create_table :categories do |t|
       t.string :name, null: false
-      t.string :ancestry
       t.timestamps
     end
     add_index :categories, :name
-    add_index :categories, :ancestry
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,10 +25,8 @@ ActiveRecord::Schema.define(version: 2020_06_19_110307) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
-    t.string "ancestry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["ancestry"], name: "index_categories_on_ancestry"
     t.index ["name"], name: "index_categories_on_name"
   end
 


### PR DESCRIPTION
 # what
categoryテーブルからancestry削除
マイグレーションファイルの順番を修正

# why
ancestryカラムは後から追加するため
マイグレーションファイルの順番を修正することで一括でmigrateできるようにした。