### PR TITLE
fix:user-validation

### DIFF
--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -90,7 +90,7 @@
 
           .form__main__destination-name
             %label.form__main__destination-name__title
-              送付先氏名（全角）
+              送付先氏名
             %span.form__main__destination-name__required
               必須
             = render "devise/registrations/error_destination", culumn: :family_name
@@ -102,7 +102,7 @@
 
           .form__main__destination-kana
             %label.form__main__destination-kana__title
-              送付先氏名かな（全角）
+              送付先氏名かな
             %span.form__main__destination-kana__required
               必須
             = render "devise/registrations/error_destination", culumn: :family_name_kana

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
# WHAT
新規登録画面のエラーメッセージ修正
①パスワード
②送付先氏名

https://gyazo.com/565144f7232ffda82eb00bfcaa59cbf7
https://gyazo.com/f04b207ba14b23a92a281978127ce33f
https://gyazo.com/c7f9663d7f9381435c7e23d69518f551

# WAY
パスワード、送付先氏名のエラーメッセージに誤りがあったため

①パスワード：修正前→５文字以下の入力だとエラーメッセージ「６文字以上入力してください」になっていたため。（指定は７文字以上）
②送付先氏名：全角の指定がなかったため、（全角）を削除。