### PR TITLE
fix:user-validation2

### DIFF
--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,10 +1,13 @@
 class Destination < ApplicationRecord
   belongs_to :user
 
-  validates :family_name, presence: true
-  validates :first_name, presence: true
-  validates :family_name_kana, presence: true
-  validates :first_name_kana, presence: true
+  hiragana = /\A[ぁ-んー－]+\z/
+  zennkaku = /\A[ぁ-んァ-ン一-龥]/
+
+  validates :family_name, presence: true, format: { with:  zennkaku }
+  validates :first_name, presence: true, format: { with:  zennkaku }
+  validates :family_name_kana, presence: true, format: { with:  hiragana }
+  validates :first_name_kana, presence: true, format: { with:  hiragana }
   validates :postal_code, presence: true, length: { is: 7}
   validates :prefecture_id, presence: true
   validates :city, presence: true

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -90,7 +90,7 @@
 
           .form__main__destination-name
             %label.form__main__destination-name__title
-              送付先氏名
+              送付先氏名（全角）
             %span.form__main__destination-name__required
               必須
             = render "devise/registrations/error_destination", culumn: :family_name
@@ -102,7 +102,7 @@
 
           .form__main__destination-kana
             %label.form__main__destination-kana__title
-              送付先氏名かな
+              送付先氏名かな（全角）
             %span.form__main__destination-kana__required
               必須
             = render "devise/registrations/error_destination", culumn: :family_name_kana

--- a/spec/factories/destination.rb
+++ b/spec/factories/destination.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :destination do
     association :user
-    family_name           {"山田"}
-    first_name            {"太郎"}
-    family_name_kana      {"やまだ"}
-    first_name_kana       {"たろう"}
+    family_name           { Gimei.last.kanji }
+    first_name            { Gimei.first.kanji }
+    family_name_kana      { Gimei.last.hiragana }
+    first_name_kana       { Gimei.first.hiragana }
     postal_code           {"0000000"}
     prefecture_id         {"愛知県"}
     city                  {"名古屋市"}

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -7,57 +7,85 @@ describe Destination do
       expect(destination).to be_valid
     end
 
-
     # 2
     it " family_nameがない場合は登録できないこと" do
       destination = build(:destination, family_name: nil)
       destination.valid?
       expect(destination.errors[:family_name]).to include("を入力してください")
     end
-
+    
     # 3
+    it " family_name全角でない場合は登録できないこと" do
+      destination = build(:destination, family_name: "yamada")
+      destination.valid?
+      expect(destination.errors[:family_name]).to include("は不正な値です")
+    end
+
+    # 4
     it " first_nameがない場合は登録できないこと" do
       destination = build(:destination, first_name: nil)
       destination.valid?
       expect(destination.errors[:first_name]).to include("を入力してください")
     end
 
-    # 4
+    # 5
+    it " first_nameが全角でない場合は登録できないこと" do
+      destination = build(:destination, first_name: "taro")
+      destination.valid?
+      expect(destination.errors[:first_name]).to include("は不正な値です")
+    end
+
+    # 6
     it " family_name_kanaがない場合は登録できないこと" do
       destination = build(:destination, family_name_kana: nil)
       destination.valid?
       expect(destination.errors[:family_name_kana]).to include("を入力してください")
     end
 
-    # 5
+    # 7
+    it " family_name_kanaがひらがなでない場合は登録できないこと" do
+      destination = build(:destination, family_name_kana: "ヤマダ")
+      destination.valid?
+      expect(destination.errors[:family_name_kana]).to include("は不正な値です")
+    end
+
+
+    # 8
     it " first_name_kanaがない場合は登録できないこと" do
       destination = build(:destination, first_name_kana: nil)
       destination.valid?
       expect(destination.errors[:first_name_kana]).to include("を入力してください")
     end
 
-    # 6
+    # 9
+    it " first_name_kanaがひらがなでない場合は登録できないこと" do
+      destination = build(:destination, first_name_kana: "タロウ")
+      destination.valid?
+      expect(destination.errors[:first_name_kana]).to include("は不正な値です")
+    end
+
+    # 10
     it " postal_codeが7文字でなければ登録できないこと " do
       destination = build(:destination, postal_code: "0000000")
       destination.valid?
       expect(destination.errors[:postal_code])
     end
 
-    # 7
+    # 11
     it " prefectureがない場合は登録できないこと" do
       destination = build(:destination, prefecture_id: nil)
       destination.valid?
       expect(destination.errors[:prefecture_id]).to include("を入力してください")
     end
 
-    # 8
+    # 12
     it " cityがない場合は登録できないこと" do
       destination = build(:destination, city: nil)
       destination.valid?
       expect(destination.errors[:city]).to include("を入力してください")
     end
 
-    # 9
+    # 13
     it " addressがない場合は登録できないこと" do
       destination = build(:destination, address: nil)
       destination.valid?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,27 +66,55 @@ describe User do
     end
 
     # 10
+    it " family_name全角でない場合は登録できないこと" do
+      user = build(:user, family_name: "yamada")
+      user.valid?
+      expect(user.errors[:family_name]).to include("は不正な値です")
+    end
+
+    # 11
     it " first_nameがない場合は登録できないこと" do
       user = build(:user, first_name: nil)
       user.valid?
       expect(user.errors[:first_name]).to include("を入力してください", "は不正な値です")
     end
 
-    # 11
+    # 12
+    it " first_nameが全角でない場合は登録できないこと" do
+      user = build(:user, first_name: "taro")
+      user.valid?
+      expect(user.errors[:first_name]).to include("は不正な値です")
+    end
+
+    # 13
     it " family_name_kanaがない場合は登録できないこと" do
       user = build(:user, family_name_kana: nil)
       user.valid?
       expect(user.errors[:family_name_kana]).to include("を入力してください", "は不正な値です")
     end
+    
+    # 14
+    it " family_name_kanaがひらがなでない場合は登録できないこと" do
+      user = build(:user, family_name_kana: "ヤマダ")
+      user.valid?
+      expect(user.errors[:family_name_kana]).to include("は不正な値です")
+    end
 
-    # 12
+    # 15
     it " first_name_kanaがない場合は登録できないこと" do
       user = build(:user, first_name_kana: nil)
       user.valid?
       expect(user.errors[:first_name_kana]).to include("を入力してください", "は不正な値です")
     end
 
-    # 13
+    # 16
+    it " first_name_kanaがひらがなでない場合は登録できないこと" do
+      user = build(:destination, first_name_kana: "タロウ")
+      user.valid?
+      expect(user.errors[:first_name_kana]).to include("は不正な値です")
+    end
+
+    # 17
     it " birthdayがない場合は登録できないこと" do
       user = build(:user, birthday: nil)
       user.valid?


### PR DESCRIPTION
# WHAT
新規登録の名前入力のバリデーション
氏名欄は全角、かな欄はひらがなのバリデーションをかけた

https://gyazo.com/dc0cbc55c5292aa0bae92e1463f39587
https://gyazo.com/dd955239b5dd26c07c53d279c8ba7505

# WHY
本人確認情報と、商品送付先住所情報の制約を統一するため

